### PR TITLE
Enable two mallets per player

### DIFF
--- a/main.py
+++ b/main.py
@@ -73,6 +73,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--mallet-radius", type=float, dest="mallet_radius", help="Mallet radius in pixels")
     parser.add_argument("--mallet-speed", type=float, dest="mallet_speed", help="Mallet max speed per tick (px)")
     parser.add_argument("--puck-speed-init", nargs=2, metavar=("MIN","MAX"), help="Initial puck speed range (px/tick)")
+    parser.add_argument("--mallets-per-side", type=int, dest="mallets_per_side", help="Number of mallets per player side")
 
     # Episode and rewards
     parser.add_argument("--max-steps", type=int, dest="max_steps", help="Max steps per episode")
@@ -139,6 +140,8 @@ def _collect_overrides(ns: argparse.Namespace) -> Dict[str, Any]:
                 with suppress(Exception):
                     overrides[k] = (float(v[0]), float(v[1]))
             continue
+        if k == "mallets_per_side":
+            overrides[k] = int(v)
         if k in config_field_names:
             overrides[k] = v
     return overrides
@@ -191,7 +194,8 @@ def main() -> None:
         # Default to 12 as per specification
         obs_dim = 12
 
-    action_space_n = 5  # As specified: stay, up, down, left, right
+    # Derive action space from env (supports multiple mallets per side)
+    action_space_n = int(getattr(env, "action_space_n", 5))
 
     # Build agents
     agent_kwargs = dict(

--- a/src/config.py
+++ b/src/config.py
@@ -78,6 +78,7 @@ class Config:
     puck_mass: float = 1.0
     mallet_radius: float = 20.0
     mallet_speed: float = 12.0  # max step speed per tick (px)
+    mallets_per_side: int = 1  # number of controllable mallets per player side
 
     # Puck initial speed (randomized magnitude range, px per tick)
     puck_speed_init: Tuple[float, float] = (3.0, 6.0)
@@ -166,6 +167,8 @@ class Config:
             raise ValueError("puck_speed_init must be a valid (min, max) with 0 <= min <= max.")
         if not (0.05 <= self.goal_height_ratio <= 0.8):
             raise ValueError("goal_height_ratio must be in [0.05, 0.8] for reasonable gameplay.")
+        if int(self.mallets_per_side) <= 0:
+            raise ValueError("mallets_per_side must be >= 1")
 
         # Keep velocity normalization consistent with configured limits
         self.vel_norm_mallet = float(self.mallet_speed)

--- a/src/render.py
+++ b/src/render.py
@@ -149,37 +149,34 @@ class Renderer:
             self.screen, self.colors["puck"], (int(puck.x), int(puck.y)), int(puck.r)
         )
 
-        # Draw mallets with shadows
-        left = state.left
-        right = state.right
+        # Draw mallets with shadows (iterate lists)
+        for left in getattr(state, "left", []):
+            pygame.draw.circle(
+                self.screen,
+                self.colors["shadow"],
+                (int(left.x) + shadow_offset, int(left.y) + shadow_offset),
+                int(left.r),
+            )
+            pygame.draw.circle(
+                self.screen,
+                self.colors["left_mallet"],
+                (int(left.x), int(left.y)),
+                int(left.r),
+            )
 
-        # Left mallet
-        pygame.draw.circle(
-            self.screen,
-            self.colors["shadow"],
-            (int(left.x) + shadow_offset, int(left.y) + shadow_offset),
-            int(left.r),
-        )
-        pygame.draw.circle(
-            self.screen,
-            self.colors["left_mallet"],
-            (int(left.x), int(left.y)),
-            int(left.r),
-        )
-
-        # Right mallet
-        pygame.draw.circle(
-            self.screen,
-            self.colors["shadow"],
-            (int(right.x) + shadow_offset, int(right.y) + shadow_offset),
-            int(right.r),
-        )
-        pygame.draw.circle(
-            self.screen,
-            self.colors["right_mallet"],
-            (int(right.x), int(right.y)),
-            int(right.r),
-        )
+        for right in getattr(state, "right", []):
+            pygame.draw.circle(
+                self.screen,
+                self.colors["shadow"],
+                (int(right.x) + shadow_offset, int(right.y) + shadow_offset),
+                int(right.r),
+            )
+            pygame.draw.circle(
+                self.screen,
+                self.colors["right_mallet"],
+                (int(right.x), int(right.y)),
+                int(right.r),
+            )
 
         # HUD: Scores, Episode, Epsilons, Step
         hud_margin = 8


### PR DESCRIPTION
Adds configurable support for multiple mallets per side to enhance gameplay complexity.

This change allows each side to control multiple mallets, expanding the game's action and observation spaces. It involved updating the game state to manage mallet lists, modifying action decoding (5^n), dynamically building observations, and adapting rendering and reward shaping to account for all mallets on a side.

---
<a href="https://cursor.com/background-agent?bcId=bc-dbbc1903-6d80-4231-8efb-306719e92344">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dbbc1903-6d80-4231-8efb-306719e92344">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Enable configurable multiple mallets per player side and adapt the environment, action space, observations, physics, rendering, and CLI to support n mallets per side.

New Features:
- Introduce mallets_per_side configuration to spawn multiple mallets per side.
- Derive the discrete action space size as 5^n and decode combined actions into per-mallet moves.
- Expand the observation vector to include positions and velocities for all mallets on each side.

Enhancements:
- Refactor spawning, reset, physics steps, collision handling, and reward computation to iterate over mallet lists.
- Update rendering to draw all mallets via list iteration and adjust state snapshots to include mallet lists.
- Extend shaping utility to compute distance terms using the nearest mallet per side.

Chores:
- Add --mallets-per-side CLI flag and enforce mallets_per_side ≥ 1 in configuration.
- Derive action_space_n dynamically in main instead of hard-coding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support multiple mallets per side, configurable via a new CLI option.
  - Rendering updated to display all mallets per side with correct visuals.
  - Action space now adapts to the environment, enabling multi-mallet control.
- Refactor
  - Configuration enhanced with a validated mallet count setting.
  - Observations and reward shaping updated to account for the nearest mallet, improving robustness and backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->