### PR TITLE
feat: support multiple mallets per side

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -78,6 +78,7 @@ class Config:
     puck_mass: float = 1.0
     mallet_radius: float = 20.0
     mallet_speed: float = 12.0  # max step speed per tick (px)
+    mallet_count: int = 1  # number of mallets per side
 
     # Puck initial speed (randomized magnitude range, px per tick)
     puck_speed_init: Tuple[float, float] = (3.0, 6.0)
@@ -135,7 +136,7 @@ class Config:
 
     # Derived/advanced options (rarely changed)
     action_space_n: int = 5
-    obs_dim: int = 12
+    obs_dim: int = 12  # updated in __post_init__ based on mallet_count
 
     # Internal: resolved device string (computed in __post_init__)
     _resolved_device: str = field(init=False, repr=False)
@@ -166,12 +167,17 @@ class Config:
             raise ValueError("puck_speed_init must be a valid (min, max) with 0 <= min <= max.")
         if not (0.05 <= self.goal_height_ratio <= 0.8):
             raise ValueError("goal_height_ratio must be in [0.05, 0.8] for reasonable gameplay.")
+        if self.mallet_count <= 0:
+            raise ValueError("mallet_count must be a positive integer.")
 
         # Keep velocity normalization consistent with configured limits
         self.vel_norm_mallet = float(self.mallet_speed)
         # If user provided a smaller vel_norm_puck than mallet speed, bump to at least mallet speed
         if self.vel_norm_puck < self.mallet_speed:
             self.vel_norm_puck = float(self.mallet_speed)
+
+        # Observation dimension: 4 puck values + 4 per mallet
+        self.obs_dim = 4 + 8 * self.mallet_count
 
         # Resolve device preference now for stable downstream use
         self._resolved_device = resolve_device(self.device)

--- a/src/render.py
+++ b/src/render.py
@@ -150,36 +150,33 @@ class Renderer:
         )
 
         # Draw mallets with shadows
-        left = state.left
-        right = state.right
+        for m in state.left:
+            pygame.draw.circle(
+                self.screen,
+                self.colors["shadow"],
+                (int(m.x) + shadow_offset, int(m.y) + shadow_offset),
+                int(m.r),
+            )
+            pygame.draw.circle(
+                self.screen,
+                self.colors["left_mallet"],
+                (int(m.x), int(m.y)),
+                int(m.r),
+            )
 
-        # Left mallet
-        pygame.draw.circle(
-            self.screen,
-            self.colors["shadow"],
-            (int(left.x) + shadow_offset, int(left.y) + shadow_offset),
-            int(left.r),
-        )
-        pygame.draw.circle(
-            self.screen,
-            self.colors["left_mallet"],
-            (int(left.x), int(left.y)),
-            int(left.r),
-        )
-
-        # Right mallet
-        pygame.draw.circle(
-            self.screen,
-            self.colors["shadow"],
-            (int(right.x) + shadow_offset, int(right.y) + shadow_offset),
-            int(right.r),
-        )
-        pygame.draw.circle(
-            self.screen,
-            self.colors["right_mallet"],
-            (int(right.x), int(right.y)),
-            int(right.r),
-        )
+        for m in state.right:
+            pygame.draw.circle(
+                self.screen,
+                self.colors["shadow"],
+                (int(m.x) + shadow_offset, int(m.y) + shadow_offset),
+                int(m.r),
+            )
+            pygame.draw.circle(
+                self.screen,
+                self.colors["right_mallet"],
+                (int(m.x), int(m.y)),
+                int(m.r),
+            )
 
         # HUD: Scores, Episode, Epsilons, Step
         hud_margin = 8

--- a/src/utils.py
+++ b/src/utils.py
@@ -111,12 +111,10 @@ def compute_shaping(env: "AirHockeyEnv", for_left: bool) -> float:
     # Distance component (normalize by table diagonal)
     diag = float(np.hypot(env.width, env.height))
     if for_left:
-        dx = env.left_mallet.x - env.puck.x
-        dy = env.left_mallet.y - env.puck.y
+        dists = [np.hypot(m.x - env.puck.x, m.y - env.puck.y) for m in env.left_mallets]
     else:
-        dx = env.right_mallet.x - env.puck.x
-        dy = env.right_mallet.y - env.puck.y
-    dist_norm = float(np.hypot(dx, dy)) / (diag if diag > 0.0 else 1.0)
+        dists = [np.hypot(m.x - env.puck.x, m.y - env.puck.y) for m in env.right_mallets]
+    dist_norm = float(min(dists)) / (diag if diag > 0.0 else 1.0)
     dist_term = 0.001 * (-dist_norm)
 
     # Time penalty


### PR DESCRIPTION
## Summary
- allow configuring number of mallets per side via `mallet_count`
- update environment, rendering, and utils to handle multiple mallets
- compute observation dimension dynamically based on mallet count

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from src.env import AirHockeyEnv
from src.config import Config
cfg=Config(mallet_count=2)
env=AirHockeyEnv(cfg)
obs_l, obs_r = env.reset(seed=0)
print(len(obs_l), len(obs_r))
for _ in range(2):
    obs_l, obs_r, r_l, r_r, done, info = env.step(0,0)
print('step ok', obs_l.shape, r_l, r_r, done)
PY`


------
https://chatgpt.com/codex/tasks/task_e_6899661e06308331b127df4909abf428