### PR TITLE
Reduce maximum puck speed by 25%

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -81,7 +81,7 @@ class Config:
     mallets_per_side: int = 2  # number of mallets each side controls
 
     # Puck initial speed (randomized magnitude range, px per tick)
-    puck_speed_init: Tuple[float, float] = (3.0, 6.0)
+    puck_speed_init: Tuple[float, float] = (2.25, 4.5)
 
     # Episode control
     max_steps: int = 2000
@@ -100,7 +100,7 @@ class Config:
     # Observation normalization
     # Positions typically scaled to [-1, 1] using table size directly.
     # Velocity normalization constants used by env/utils during scaling.
-    vel_norm_puck: float = 5.0  # expected max magnitude for puck velocity (px/tick)
+    vel_norm_puck: float = 3.75  # expected max magnitude for puck velocity (px/tick)
     vel_norm_mallet: float = 9.0  # equals mallet_speed by default
     mirror_right_obs: bool = True  # mirror horizontally for right agent's perspective
 


### PR DESCRIPTION
Reduce the maximum puck speed by 25%.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea1241c5-7eb1-4ea9-932b-bbb7ece96640">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ea1241c5-7eb1-4ea9-932b-bbb7ece96640">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Reduce the maximum puck speed by 25% across the environment.

Enhancements:
- Adjust puck initial speed range from (3.0, 6.0) to (2.25, 4.5).
- Lower puck velocity normalization constant from 5.0 to 3.75.